### PR TITLE
feat: migrate 2D data from version 3 to 4

### DIFF
--- a/src/migration/MigrationManager.ts
+++ b/src/migration/MigrationManager.ts
@@ -1,8 +1,9 @@
 import migrateToVersion1 from './migrateToVersion1';
 import migrateToVersion2 from './migrateToVersion2';
 import migrateToVersion3 from './migrateToVersion3';
+import migrateToVersion4 from './migrateToVersion4';
 
-export const CURRENT_EXPORT_VERSION = 3;
+export const CURRENT_EXPORT_VERSION = 4;
 
 function migrationPipe(functions: ((data: any) => any)[]) {
   return (input: any) => functions.reduce((input, func) => func(input), input);
@@ -13,6 +14,7 @@ export function migrate(data: any): any {
     migrateToVersion1,
     migrateToVersion2,
     migrateToVersion3,
+    migrateToVersion4,
   ];
   let index = data?.version || 0;
 

--- a/src/migration/migrateToVersion4.ts
+++ b/src/migration/migrateToVersion4.ts
@@ -1,9 +1,9 @@
 /*  NMRium Version: 0.33.0
     Notes: Any 2d file containing fid spectra should be regenerated with nmr-load-save package because the parser did not handle it correctly before this version
 
-    * changes from version 3 to version 4:
-       change the 2d data structure, in version 3 the 2D FT spectra have this structure which represents the real part that should be migrated to the new structure for 2D
-        FT which contains `rr`, `ii`, `ri` and `ir` where `r` stands for the real part and `i` stands for the imaginary part
+    *changes from version 3 to version 4:
+      1- change the 2d data structure, in version 3 the 2D FT spectra have this structure which represents the real part that should be migrated to the new structure for 2D
+         FT which contains `rr`, `ii`, `ri` and `ir` where `r` stands for the real part and `i` stands for the imaginary part
             Data
                 {
                     data: {
@@ -34,22 +34,31 @@
                             }
                 }
 
-
             paths:
               - spectra > data
+
+      2- skip the 2D FID spectra.
+
     */
 
 export default function migrateToVersion4(data: any): any {
   if (data?.version === 4) return data;
 
-  const newData = { ...data, version: 4 };
+  const spectra = [];
 
-  for (const spectrum of newData.spectra) {
+  for (const spectrum of data.spectra) {
     const { dimension, isFt } = spectrum.info;
-    if (dimension === 2 && isFt) {
-      spectrum.data = { rr: spectrum.data };
+    if (dimension === 2) {
+      if (isFt) {
+        spectrum.data = { rr: spectrum.data };
+      } else {
+        // skip pushing 2d fid spectrum to spectra array
+        continue;
+      }
     }
+
+    spectra.push(spectrum);
   }
 
-  return newData;
+  return { ...data, spectra, version: 4 };
 }

--- a/src/migration/migrateToVersion4.ts
+++ b/src/migration/migrateToVersion4.ts
@@ -1,0 +1,55 @@
+/*  NMRium Version: 0.33.0
+    Notes: Any 2d file containing fid spectra should be regenerated with nmr-load-save package because the parser did not handle it correctly before this version
+
+    * changes from version 3 to version 4:
+       change the 2d data structure, in version 3 the 2D FT spectra have this structure which represents the real part that should be migrated to the new structure for 2D
+        FT which contains `rr`, `ii`, `ri` and `ir` where `r` stands for the real part and `i` stands for the imaginary part
+            Data
+                {
+                    data: {
+                            z:Array<Array<Float64Array>>,
+                            minX:number,
+                            maxX:number,
+                            minY:number,
+                            maxY:number,
+                            minZ:number,
+                            maxZ:number,
+                            noise:number
+                        }
+                }
+
+                =>
+               {
+                    data: {
+                            rr: {
+                                    z:Array<Array<Float64Array>>,
+                                    minX:number,
+                                    maxX:number,
+                                    minY:number,
+                                    maxY:number,
+                                    minZ:number,
+                                    maxZ:number,
+                                    noise:number
+                                }
+                            }
+                }
+
+
+            paths:
+              - spectra > data
+    */
+
+export default function migrateToVersion4(data: any): any {
+  if (data?.version === 4) return data;
+
+  const newData = { ...data, version: 4 };
+
+  for (const spectrum of newData.spectra) {
+    const { dimension, isFt } = spectrum.info;
+    if (dimension === 2 && isFt) {
+      spectrum.data = { rr: spectrum.data };
+    }
+  }
+
+  return newData;
+}

--- a/src/migration/migrateToVersion4.ts
+++ b/src/migration/migrateToVersion4.ts
@@ -47,7 +47,10 @@ export default function migrateToVersion4(data: any): any {
   const spectra = [];
   for (const spectrum of data.spectra) {
     //only migrate raw data
-    if (!spectrum.source?.jcampURL) {
+    if (
+      !spectrum.source ||
+      !['jcampURL', 'jcamp'].some((key) => key in spectrum.source)
+    ) {
       const { dimension, isFt } = spectrum.info;
       if (dimension === 2) {
         if (isFt) {

--- a/src/migration/migrateToVersion4.ts
+++ b/src/migration/migrateToVersion4.ts
@@ -45,18 +45,19 @@ export default function migrateToVersion4(data: any): any {
   if (data?.version === 4) return data;
 
   const spectra = [];
-
   for (const spectrum of data.spectra) {
-    const { dimension, isFt } = spectrum.info;
-    if (dimension === 2) {
-      if (isFt) {
-        spectrum.data = { rr: spectrum.data };
-      } else {
-        // skip pushing 2d fid spectrum to spectra array
-        continue;
+    //only migrate raw data
+    if (!spectrum.source?.jcampURL) {
+      const { dimension, isFt } = spectrum.info;
+      if (dimension === 2) {
+        if (isFt) {
+          spectrum.data = { rr: spectrum.data };
+        } else {
+          // skip pushing 2d fid spectrum to spectra array
+          continue;
+        }
       }
     }
-
     spectra.push(spectrum);
   }
 


### PR DESCRIPTION
NMRium Version: 0.33.0

 Notes: Any 2d file containing fid spectra should be regenerated with nmr-load-save package because the parser did not 
    handle it correctly before this version

    changes from version 3 to version 4:
         change the 2d data structure, in version 3 the 2D FT spectra have this structure which represents the real part that should 
           be migrated to the new structure for 2D FT which contains `rr`, `ii`, `ri` and `ir` where `r` stands for the real part and `i` 
           stands for the imaginary part
           
          Data
               { 
                    data: {
                            z:Array<Array<Float64Array>>,
                            minX:number,
                            maxX:number,
                            minY:number,
                            maxY:number,
                            minZ:number,
                            maxZ:number,
                            noise:number
                        }
                }

                =>
               {
                    data: {
                            rr: {
                                    z:Array<Array<Float64Array>>,
                                    minX:number,
                                    maxX:number,
                                    minY:number,
                                    maxY:number,
                                    minZ:number,
                                    maxZ:number,
                                    noise:number
                                }
                            }
                }


            paths:
              - spectra > data